### PR TITLE
Fix: The 'https://jquery-limit.googlecode.com/files/jquery.limit-1.2.js' file could not be downloaded (HTTP/1.1 404 Not Found)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
                 "name": "jquery/limit",
                 "version": "1.2.0",
                 "dist": {
-                    "url": "https://jquery-limit.googlecode.com/files/jquery.limit-1.2.js",
+                    "url": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/jquery-limit/jquery.limit-1.2.js",
                     "type": "file"
                 }
             }


### PR DESCRIPTION
# Description

This PR fixes jquery/limit composer installation failure
